### PR TITLE
Merge in changes made to prepare for brownbag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-ansible.cfg
+

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+allow_world_readable_tmpfiles = True  # Required in 2.1.x to use become.
+
+[ssh_connection]
+pipelining = True

--- a/roles/sentry/templates/sentry.crontab
+++ b/roles/sentry/templates/sentry.crontab
@@ -1,1 +1,1 @@
-0 3 * * * sentry {{ sentry_root }}/env.d/bin/sentry --config={{ sentry_root }}/sentry.conf.py cleanup --days=30
+0 3 * * * sentry SENTRY_CONF=/etc/sentry {{ sentry_root }}/env.d/bin/sentry cleanup --days=30

--- a/roles/sentry/templates/sentry.vhost.j2
+++ b/roles/sentry/templates/sentry.vhost.j2
@@ -22,7 +22,14 @@ server {
   client_max_body_size 5m;
   client_body_buffer_size 100k;
 
+  {% if sentry_organization is defined %}
+  # Redirect users to the sole organization's signin page.
+  location = / {
+    return 301 /{{ sentry_organization }}/;
+  }
+  {% endif %}
+
   location / {
-    proxy_pass        http://localhost:9000;
+    proxy_pass http://localhost:9000;
   }
 }


### PR DESCRIPTION
- Fix incorrect path in the nightly cleanup cron job.
- Add a redirect from / to /sight-machine/ for convenience.
- [Fix postgresql tasks on ansible 2.1.x by setting `allow_world_readable_tmpfiles`.](https://github.com/ansible/ansible/issues/16048) This mimics the behavior of ansible < 2.1.0.
