### PR TITLE
Fix redis cache overflow

### DIFF
--- a/roles/redis/files/redis_cache.conf
+++ b/roles/redis/files/redis_cache.conf
@@ -18,7 +18,7 @@ appendonly no
 # It's better to drop events on overflow than to let the server die.
 maxclients 1000
 maxmemory 200mb
-maxmemory-policy noeviction
+maxmemory-policy volatile-lru
 
 lua-time-limit 5000
 


### PR DESCRIPTION
In some cases sentry may receive messages so quickly that it would overflow the cache. When this happens we want to drop cached objects instead of forcing sentry into a failure loop until the cache process is restarted.
