### PR TITLE
Bump sentry to 8.17.0, unpin redis

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -3,7 +3,7 @@
   apt_repository: repo='ppa:chris-lea/redis-server' update_cache=yes state=present
 
 - name: install redis
-  apt: name=redis-server=3:3.0.7-1chl1~trusty1 state=present
+  apt: name=redis-server state=present
   notify:
     - restart redis
 

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -21,7 +21,15 @@
   become_method: sudo
 
 - name: install sentry package
-  pip: name=sentry version=8.12.0 virtualenv={{ sentry_root }}/env.d/
+  pip: name=sentry version=8.17.0 virtualenv={{ sentry_root }}/env.d/
+  become: yes
+  become_user: sentry
+  become_method: sudo
+  notify:
+    - restart sentry
+
+- name: install sentry plugins package
+  pip: name=sentry-plugins version=8.17.0 virtualenv={{ sentry_root }}/env.d/
   become: yes
   become_user: sentry
   become_method: sudo


### PR DESCRIPTION
Version bump requested by @nendo and @tkerbosch.

Also:
* Pulled in sentry-plugins, because someone had manually installed sentry-jira and sentry-github on the server. :angry: 
* Unpinned redis because the PPA keeps deleting old versions, which breaks the build. :-1: 